### PR TITLE
fix_ItemsController_and_PurchasesController

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :destroy]
+  before_action :authenticate_user!, except: [:show]
 
   def new
     @item = Item.new

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,4 +1,5 @@
 class PurchasesController < ApplicationController
+  before_action :authenticate_user!
 
   require 'payjp'
   require 'date'

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -12,10 +12,10 @@
     %br
     .user__btn_fb
       = image_tag 'facebook_icon.png',size: "35x35" , class: "facebook-icon"
-      = link_to "Facebookで登録",user_facebook_omniauth_authorize_path, class: "new-register", method: :post
+      = link_to "Facebookでログイン",user_facebook_omniauth_authorize_path, class: "new-register", method: :post
     .user__btn_google
       = image_tag 'google_icon.png',size: "37x37" , class: "google-icon "
-      = link_to "Googleで登録",user_google_oauth2_omniauth_authorize_path, class: "google-register", method: :post
+      = link_to "Googleでログイン",user_google_oauth2_omniauth_authorize_path, class: "google-register", method: :post
     %br
     %br
     = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|


### PR DESCRIPTION
# WHAT
・商品購入と商品出品を、ログインユーザーだけができるようにする。
・ログインページの表記を修正する


# WHY
・現状、ログインしていないユーザーも購入や出品ができてしまうため
・表記が間違っていたため