### PR TITLE
Create sold out view

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -5,6 +5,7 @@ $red: #ea352d;
 $border_gray: rgb(230, 230, 230);
 $border_gray-thick: rgb(212, 211, 211);
 $btn_gray: #aaa;
+$btn_thick-gray: gray;
 $form_gray: rgb(136, 135, 135);
 $fa_icon_gray: #b6b6b6;
 $white: #fff;

--- a/app/assets/stylesheets/partials/_item-show.scss
+++ b/app/assets/stylesheets/partials/_item-show.scss
@@ -55,7 +55,25 @@
   padding: 2px;
 }
 
+#btn-soldout {
+  background-color: $btn_thick-gray;
+  border: $btn_thick-gray;
+
+  a {
+    font: {
+      size: 24px;
+      weight: bold;
+    }
+
+    cursor: no-drop;
+  }
+
+}
+
 .btn-detail {
+  max-width: 650px;
+  padding: 0 0 15px 0;
+
   font: {
     size: 24px;
     weight: bold;
@@ -78,6 +96,33 @@
   max-width: 230px;
   max-height: 230px;
   margin-left: 33px;
+  position: relative;
+  z-index: 0px;
+}
+
+.image_soldout_red-triangle {
+  width: 0;
+  height: 0;
+  border-left: 120px solid $red;
+  border-right: 120px solid transparent;
+  border-bottom: 120px solid transparent;
+  position: absolute;
+  top: 327px;
+  z-index: 20px;
+
+}
+
+.image_soldout_red-letter {
+  p {
+    color: $white;
+    font-weight: 600;
+    font-size: 25px;
+    transform: rotate(-45deg);
+    letter-spacing: 2px;
+    z-index: 30px;
+    position: absolute;
+    top: 355px;
+  }
 }
 
 .item_s-img {

--- a/app/assets/stylesheets/partials/_item-show.scss
+++ b/app/assets/stylesheets/partials/_item-show.scss
@@ -107,7 +107,7 @@
   border-right: 120px solid transparent;
   border-bottom: 120px solid transparent;
   position: absolute;
-  top: 327px;
+  top: 290px;
   z-index: 20px;
 
 }
@@ -121,7 +121,7 @@
     letter-spacing: 2px;
     z-index: 30px;
     position: absolute;
-    top: 355px;
+    top: 320px;
   }
 }
 

--- a/app/assets/stylesheets/partials/_item-show.scss
+++ b/app/assets/stylesheets/partials/_item-show.scss
@@ -67,7 +67,6 @@
 
     cursor: no-drop;
   }
-
 }
 
 .btn-detail {
@@ -109,7 +108,6 @@
   position: absolute;
   top: 290px;
   z-index: 20px;
-
 }
 
 .image_soldout_red-letter {

--- a/app/assets/stylesheets/partials/_search_items.scss
+++ b/app/assets/stylesheets/partials/_search_items.scss
@@ -155,7 +155,6 @@
   position: absolute;
   top: 0;
   z-index: 20px;
-
 }
 
 .image_soldout_red-letter-search-item {

--- a/app/assets/stylesheets/partials/_search_items.scss
+++ b/app/assets/stylesheets/partials/_search_items.scss
@@ -16,6 +16,7 @@
     color: $btn-gray;
     z-index: 10;
   }
+
   .fas {
     color: $form-gray;
   }
@@ -41,16 +42,20 @@
     &__main {
       background-color: $white;
       padding: 15px;
+
       &__heading {
         font-weight: bold;
         margin-bottom: 20px;
       }
+
       &__requirement {
         margin-bottom: 25px;
+
         &__title {
           font-weight: bold;
           margin-bottom: 5px;
         }
+
         &__input {
           .text_field {
             @extend .form;
@@ -58,13 +63,16 @@
             height: 50px;
             padding: 10px;
           }
+
           &__checkboxes {
             display: flex;
             flex-flow: row wrap;
             justify-content: space-between;
+
             &__checkbox {
               width: 48%;
               font-size: 0.95rem;
+
               .search-checkbox {
                 -webkit-appearance: checkbox;
               }
@@ -72,14 +80,17 @@
           }
         }
       }
+
       &__btn {
         display: flex;
         justify-content: space-around;
+
         &__graybtn {
           width: 40%;
           @extend .graybtn;
           color: $white;
         }
+
         &__redbtn {
           width: 40%;
           @extend .redbtn;
@@ -91,29 +102,38 @@
   &__right-container {
     width: 900px;
     padding-left: 30px;
+
     &__heading {
       font-size: 1.2rem;
+
       &--keyword {
         font-weight: bold;
       }
+
       &__result {
         margin-top: 10px;
+
         &--count {
           color: $btn-gray;
           font-size: 0.7rem;
         }
+
         &--nothing {
           font-size: 0.9rem;
         }
       }
     }
+
     &__main {
       display: flex;
       justify-content: space-between;
+
       .item-box {
         .item {
           width: 22%;
           margin: 0 20px 20px 0;
+          position: relative;
+
           .banner-mercari-info-hand-phone {
             width: 100%;
             height: 180px;
@@ -122,5 +142,32 @@
         }
       }
     }
+  }
+}
+
+
+.image_soldout_red-triangle-search-item {
+  width: 0;
+  height: 0;
+  border-left: 100px solid $red;
+  border-right: 100px solid transparent;
+  border-bottom: 100px solid transparent;
+  position: absolute;
+  top: 0;
+  z-index: 20px;
+
+}
+
+.image_soldout_red-letter-search-item {
+  p {
+    color: $white;
+    font-weight: 600;
+    font-size: 20px;
+    transform: rotate(-45deg);
+    letter-spacing: 2px;
+    z-index: 30px;
+    position: absolute;
+    top: 25px;
+    right: 35px;
   }
 }

--- a/app/assets/stylesheets/partials/_top-category-user.scss
+++ b/app/assets/stylesheets/partials/_top-category-user.scss
@@ -217,7 +217,6 @@ $height_pixel: 44px;
   position: absolute;
   top: 53px;
   z-index: 20px;
-
 }
 
 .image_soldout_red-letter-top {

--- a/app/assets/stylesheets/partials/_top-category-user.scss
+++ b/app/assets/stylesheets/partials/_top-category-user.scss
@@ -1,32 +1,42 @@
 $height_pixel: 44px;
+
 .header {
   .header-lower-right {
     li.menu__user-menu {
       width: 82.39px;
       padding-left: 14px;
+
       .nav-user-profile-img {
         border-radius: 30px;
       }
+
       a.menu__user-menu__button {
         text-decoration: none;
       }
+
       a:hover {
-        color: $light_blue; /*リンクにマウスが乗ったら背景色を変更する*/
+        color: $light_blue;
+        /*リンクにマウスが乗ったら背景色を変更する*/
       }
+
       i.fa-list-ul {
         color: $red;
       }
+
       ul.menu__second-level.user {
         right: 30px;
+
         .text-box {
           .user-name {
             font-size: 16px;
           }
+
           padding-top: 15px;
           line-height: 15px;
           text-align: center;
           margin-bottom: 10px;
         }
+
         .user-box {
           .user-profile-img {
             top: 30px;
@@ -34,16 +44,20 @@ $height_pixel: 44px;
             left: 130px;
             border-radius: 30px;
           }
+
           min-height: 80px;
+
           img {
             float: left;
           }
+
           .fa-chevron-right {
             text-align: center;
             position: absolute;
             right: -20px;
             top: 50%;
           }
+
           .text-box {
             font-size: 16px;
             color: $fa_icon_gray;
@@ -54,24 +68,29 @@ $height_pixel: 44px;
             margin-bottom: 10px;
           }
         }
+
         .sale-point {
           margin-bottom: 20px;
+
           &__textbox {
             margin: 0 16px;
             height: 40px;
             background: $background_gray;
             border: 1px solid $border_gray;
+
             &__title {
               position: absolute;
               left: 20px;
               float: left;
             }
+
             &__value {
               font-size: 14px;
               position: absolute;
               right: 35px;
               margin-right: 8px;
             }
+
             &__arrow {
               font-size: 8px;
               color: $fa_icon_gray;
@@ -80,21 +99,25 @@ $height_pixel: 44px;
             }
           }
         }
+
         .user-nav-items {
           &__item {
             width: 100%;
             border-top: 1px solid $border_gray;
             background: $background_gray;
             height: 50px;
+
             &__text {
               position: absolute;
             }
+
             &__arrow {
               position: absolute;
               right: 20px;
             }
           }
         }
+
         width: 320px;
         visibility: hidden;
         opacity: 0;
@@ -106,67 +129,106 @@ $height_pixel: 44px;
         position: absolute;
         top: 40px;
         background: $white;
+
         a {
           padding: 0 16px;
           text-decoration: none;
         }
+
         li:hover {
           background: $white;
           color: $white;
+
           a.second-level {
             color: black;
           }
         }
       }
     }
+
     li.menu__user-menu:hover ul.menu__second-level {
       list-style: none;
       top: $height_pixel;
       visibility: visible;
       opacity: 1;
     }
+
     .title-mypage {
       position: absolute;
       top: 0;
       left: 50px;
     }
+
     /* floatクリア */
     .menu:before,
     .menu:after {
       content: " ";
       display: table;
     }
-    .menu > li.menu__user-menu {
+
+    .menu>li.menu__user-menu {
       position: relative;
     }
+
     .menu__second-level li a:hover {
       background: ＄white;
       color: ＄white;
     }
+
     .header-lower-left ul.menu li.menu__user-menu {
       width: 135.797px;
       padding-left: 11px;
     }
-    .menu > li {
+
+    .menu>li {
       a.last {
         pointer-events: none;
         color: $almost-white;
       }
+
       float: left;
       height: $height_pixel;
-      line-height: 35x;
+      line-height: 35px;
       background: $white;
+
       a {
         display: block;
         color: black;
         font-size: 14px;
+
         a.menu__user-menu__button:hover {
           color: $light_blue;
         }
+
         i.fa-tag {
           color: $red;
         }
       }
     }
+  }
+}
+
+.image_soldout_red-triangle-top {
+  width: 0;
+  height: 0;
+  border-left: 100px solid $red;
+  border-right: 100px solid transparent;
+  border-bottom: 100px solid transparent;
+  position: absolute;
+  top: 53px;
+  z-index: 20px;
+
+}
+
+.image_soldout_red-letter-top {
+  p {
+    color: $white;
+    font-weight: 600;
+    font-size: 20px;
+    transform: rotate(-45deg);
+    letter-spacing: 2px;
+    z-index: 30px;
+    position: absolute;
+    top: 80px;
   }
 }

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -33,9 +33,9 @@ $height_pixel: 44px;
       font-weight: bold;
     }
 
-  .header {
-    z-index: 3;
-    margin: auto;
+    .header {
+      z-index: 3;
+      margin: auto;
     }
   }
 
@@ -86,6 +86,7 @@ $height_pixel: 44px;
         height: 40px;
         width: 40px;
         border-color: $background_gray;
+        cursor: pointer;
       }
 
       .fa-search {
@@ -183,6 +184,7 @@ $height_pixel: 44px;
 }
 
 .top {
+
   .pickup-categories,
   .pickup-brands {
     &__title {

--- a/app/views/items/search_items.html.haml
+++ b/app/views/items/search_items.html.haml
@@ -132,7 +132,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-search-item
                 .image_soldout_red-letter-search-item
                   %p SOLD

--- a/app/views/items/search_items.html.haml
+++ b/app/views/items/search_items.html.haml
@@ -132,4 +132,8 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-search-item
+                .image_soldout_red-letter-search-item
+                  %p SOLD
     = paginate @searched_items

--- a/app/views/items/search_items.html.haml
+++ b/app/views/items/search_items.html.haml
@@ -132,7 +132,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-search-item
                 .image_soldout_red-letter-search-item
                   %p SOLD

--- a/app/views/items/show.haml
+++ b/app/views/items/show.haml
@@ -17,6 +17,12 @@
             - @item.item_images.each do |image|
               %li
                 = image_tag image.image_url.to_s, class:'item_s-img'
+
+          -# --------------商品購入後、表示------------------
+          .image_soldout_red-triangle
+          .image_soldout_red-letter
+            %p SOLD
+
         .item__info__inner-content__table
         %table
           %tbody
@@ -88,6 +94,8 @@
         - if @item.deal.seller != current_user
           .item__info__inner-content__purchase-btn#btn-detail
             = link_to "購入画面に進む", new_item_purchase_path(@item), class:'btn-detail'
+          .item__info__inner-content__purchase-btn#btn-soldout
+            %a 売り切れました
 
         -# --------------どちらのページも表示------------------
         .item__info__inner-content__text

--- a/app/views/items/show.haml
+++ b/app/views/items/show.haml
@@ -19,7 +19,7 @@
                 = image_tag image.image_url.to_s, class:'item_s-img'
 
           -# --------------商品取引中・売却済後、表示------------------
-        - if @item.deal.status.id == 2 || @item.deal.status.id == 3
+        - unless @item.deal.status.id == 1
           .image_soldout_red-triangle
           .image_soldout_red-letter
             %p SOLD
@@ -98,7 +98,7 @@
               = link_to "購入画面に進む", new_item_purchase_path(@item), class:'btn-detail'
 
         -# --------------商品取引中・売却済後、表示------------------
-        - if @item.deal.status.id == 2 || @item.deal.status.id == 3
+        - unless @item.deal.status.id == 1
           .item__info__inner-content__purchase-btn#btn-soldout
             %a 売り切れました
 

--- a/app/views/items/show.haml
+++ b/app/views/items/show.haml
@@ -19,7 +19,7 @@
                 = image_tag image.image_url.to_s, class:'item_s-img'
 
           -# --------------商品取引中・売却済後、表示------------------
-        - unless @item.deal.status.id == 1
+        - unless @item.deal.status_id == 1
           .image_soldout_red-triangle
           .image_soldout_red-letter
             %p SOLD
@@ -93,12 +93,12 @@
                 着払い
         -# --------------current_userの時、非表示------------------
         - if @item.deal.seller != current_user
-          - if @item.deal.status.id == 1
+          - if @item.deal.status_id == 1
             .item__info__inner-content__purchase-btn#btn-detail
               = link_to "購入画面に進む", new_item_purchase_path(@item), class:'btn-detail'
 
         -# --------------商品取引中・売却済後、表示------------------
-        - unless @item.deal.status.id == 1
+        - unless @item.deal.status_id == 1
           .item__info__inner-content__purchase-btn#btn-soldout
             %a 売り切れました
 

--- a/app/views/items/show.haml
+++ b/app/views/items/show.haml
@@ -18,7 +18,8 @@
               %li
                 = image_tag image.image_url.to_s, class:'item_s-img'
 
-          -# --------------商品購入後、表示------------------
+          -# --------------商品取引中・売却済後、表示------------------
+        - if @item.deal.status.id == 2 || @item.deal.status.id == 3
           .image_soldout_red-triangle
           .image_soldout_red-letter
             %p SOLD
@@ -92,8 +93,12 @@
                 着払い
         -# --------------current_userの時、非表示------------------
         - if @item.deal.seller != current_user
-          .item__info__inner-content__purchase-btn#btn-detail
-            = link_to "購入画面に進む", new_item_purchase_path(@item), class:'btn-detail'
+          - if @item.deal.status.id == 1
+            .item__info__inner-content__purchase-btn#btn-detail
+              = link_to "購入画面に進む", new_item_purchase_path(@item), class:'btn-detail'
+
+        -# --------------商品取引中・売却済後、表示------------------
+        - if @item.deal.status.id == 2 || @item.deal.status.id == 3
           .item__info__inner-content__purchase-btn#btn-soldout
             %a 売り切れました
 

--- a/app/views/top/index.haml
+++ b/app/views/top/index.haml
@@ -44,7 +44,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -63,7 +63,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -82,7 +82,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -101,7 +101,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -124,7 +124,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -143,7 +143,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -162,7 +162,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -181,7 +181,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal.status.id == 1
+            - unless item.deal_status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD

--- a/app/views/top/index.haml
+++ b/app/views/top/index.haml
@@ -181,7 +181,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - unless item.deal_status_id == 1
+            - unless item.deal.status_id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD

--- a/app/views/top/index.haml
+++ b/app/views/top/index.haml
@@ -44,6 +44,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
     .pickup-category
@@ -59,6 +63,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
     .pickup-category
@@ -74,6 +82,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
     .pickup-category
@@ -89,6 +101,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
 
@@ -108,6 +124,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
     .pickup-category
@@ -123,6 +143,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
     .pickup-category
@@ -138,6 +162,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-category__show-all'
 
     .pickup-category
@@ -153,6 +181,10 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
+            - if item.deal.status.id == 2 || item.deal.status.id == 3
+              .image_soldout_red-triangle-top
+              .image_soldout_red-letter-top
+                %p SOLD
       = link_to ' すべての商品を見る',"#",class:'pickup-brand__show-all'
 
 

--- a/app/views/top/index.haml
+++ b/app/views/top/index.haml
@@ -44,7 +44,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -63,7 +63,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -101,7 +101,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -124,7 +124,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -143,7 +143,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -162,7 +162,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD
@@ -181,7 +181,7 @@
               .item__lower__price
                 = "¥ #{item.price.to_s(:delimited)}"
               .item__lower__tax (税込)
-            - if item.deal.status.id == 2 || item.deal.status.id == 3
+            - unless item.deal.status.id == 1
               .image_soldout_red-triangle-top
               .image_soldout_red-letter-top
                 %p SOLD


### PR DESCRIPTION
# What
売却済後に表示するbtnとsoldアイコンの作成。
top#index
item#show
item#search_item


# Why
商品購入後、soldoutの表示を出して、
購入画面にとばないようにするため。

![top:index](https://user-images.githubusercontent.com/50019833/59661195-3852ce80-91e5-11e9-826a-eda9ae89b147.png)
![item:show](https://user-images.githubusercontent.com/50019833/59661201-3f79dc80-91e5-11e9-8900-659190edda62.png)
![search_item_view](https://user-images.githubusercontent.com/50019833/59661206-41dc3680-91e5-11e9-87b1-7132817c1d5f.png)

